### PR TITLE
add ability to define modem serial pins

### DIFF
--- a/src/esp32-BG95.cpp
+++ b/src/esp32-BG95.cpp
@@ -4,9 +4,13 @@ bool (*parseMQTTmessage)(uint8_t,String,String);
 void(*tcpOnClose)(uint8_t clientID);
 
 void MODEMBGXX::init_port(uint32_t baudrate, uint32_t serial_config) {
+	init_port(baudrate, serial_config, 16, 17);
+}
+
+void MODEMBGXX::init_port(uint32_t baudrate, uint32_t serial_config, uint8_t rx_pin, uint8_t tx_pin) {
 
 	//modem->begin(baudrate);
-	modem->begin(baudrate,serial_config,16,17);
+	modem->begin(baudrate,serial_config, rx_pin, tx_pin);
 	#ifdef DEBUG_BG95
 	log("modem bus inited");
 	#endif

--- a/src/esp32-BG95.hpp
+++ b/src/esp32-BG95.hpp
@@ -77,6 +77,7 @@ class MODEMBGXX {
 		* call it to initialize serial port
 		*/
 		void init_port(uint32_t baudrate, uint32_t config);
+		void init_port(uint32_t baudrate, uint32_t serial_config, uint8_t tx_pin, uint8_t rx_pin);
 		/*
 		* call it to disable serial port
 		*/


### PR DESCRIPTION
Hi, I added an overloaded constructor to allow setting up modem Serial on user defined pins. I can also look into adding a platformio library file so that it can included from PIO via 

`lib_deps = zimbora/esp32-BG95`
