### PR TITLE
add SNI to SSL configuration

### DIFF
--- a/src/esp32-BG95.cpp
+++ b/src/esp32-BG95.cpp
@@ -188,11 +188,14 @@ bool MODEMBGXX::set_ssl(uint8_t ssl_cid){
 	//if(!check_command("AT+QSSLCFG=\"ciphersuite\","+String(ssl_cid)+",0X0035","OK","ERROR")) // TLS_RSA_WITH_AES_256_CBC_SHA
 		return false;
 
-	//if(!check_command("AT+QSSLCFG=\"seclevel\","+String(ssl_cid)+",0","OK","ERROR")) // No authentication
-	if(!check_command("AT+QSSLCFG=\"seclevel\","+String(ssl_cid)+",0","OK","ERROR"))
+	//if(!check_command("AT+QSSLCFG=\"seclevel\","+String(ssl_cid)+",1","OK","ERROR")) // Verify server certificate
+	if(!check_command("AT+QSSLCFG=\"seclevel\","+String(ssl_cid)+",0","OK","ERROR")) //Don't verify server certificate
 		return false;
 
-	if(!check_command("AT+QSSLCFG=\"cacert\","+String(ssl_cid)+",\"cacert.pem\"","OK","ERROR"))
+	if(!check_command("AT+QSSLCFG=\"SNI\","+String(ssl_cid)+",1","OK","ERROR")) //set SNI (required for some servers hosting multiple domains/certs on a single IP)
+		return false;
+
+	if(!check_command("AT+QSSLCFG=\"cacert\","+String(ssl_cid)+",\"cacert.pem\"","OK","ERROR")) //Not needed for seclevel 0
 		return false;
 
 	return true;


### PR DESCRIPTION
enabling SNI fixed the issue of not being able to connect to the HiveMQ server. Apparently most browsers and other TLS clients already have this enabled by default, but the BG95 does not. You have to manually enable it. SNI adds the hostname to the TLS handshake which allows the server to know which hostname on the server is being requested. This is important when many hostname (virtual hosts) are being served on the same IP because the server provides different certificates, etc for different hostname requests. 